### PR TITLE
📦 NEW: Add ssm endpoint value accordingly with cluster mode

### DIFF
--- a/ssm.tf
+++ b/ssm.tf
@@ -2,9 +2,8 @@ resource "aws_ssm_parameter" "redis_endpoint" {
   name        = "/elasticache/redis/${var.env}-${var.name}/ENDPOINT"
   description = "Elasticache Redis Endpoint"
   type        = "String"
-  value       = aws_elasticache_replication_group.redis.primary_endpoint_address
+  value       = aws_elasticache_replication_group.redis.cluster_enabled ? aws_elasticache_replication_group.redis.configuration_endpoint_address : aws_elasticache_replication_group.redis.primary_endpoint_address
 }
-
 resource "aws_ssm_parameter" "redis_port" {
   name        = "/elasticache/redis/${var.env}-${var.name}/PORT"
   description = "Elasticache Redis Port"


### PR DESCRIPTION
Set SSM endpoint value accordingly with cluster mode.
Following AWS docs -> https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Endpoints.html#:~:text=Use%20the%20Configuration,enabled)%20cluster%20endpoints.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.