### PR TITLE
Update from aws_subnet_ids to aws_subnets due to deprecation

### DIFF
--- a/_data.tf
+++ b/_data.tf
@@ -2,8 +2,11 @@ data "aws_vpc" "selected" {
   id = var.vpc_id
 }
 
-data "aws_subnet_ids" "selected" {
-  vpc_id = data.aws_vpc.selected.id
+data "aws_subnets" "selected" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.selected.id]
+  }
 
   tags = {
     Scheme = "private"

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "random_id" "salt" {
 
 resource "aws_elasticache_replication_group" "redis" {
   replication_group_id          = format("%.20s", "${var.name}-${var.env}")
-  replication_group_description = "Terraform-managed ElastiCache replication group for ${var.name}-${var.env}-${var.vpc_id}"
+  description                   = "Terraform-managed ElastiCache replication group for ${var.name}-${var.env}-${var.vpc_id}"
   node_type                     = var.redis_node_type
   automatic_failover_enabled    = var.redis_failover
   auto_minor_version_upgrade    = var.auto_minor_version_upgrade

--- a/main.tf
+++ b/main.tf
@@ -65,5 +65,5 @@ resource "aws_elasticache_parameter_group" "redis_parameter_group" {
 
 resource "aws_elasticache_subnet_group" "redis_subnet_group" {
   name       = replace(format("%.255s", lower(replace("tf-redis-${var.name}-${var.env}-${var.vpc_id}", "_", "-"))), "/\\s/", "-")
-  subnet_ids = data.aws_subnet_ids.selected.ids
+  subnet_ids = data.aws_subnets.selected.ids
 }

--- a/main.tf
+++ b/main.tf
@@ -33,14 +33,8 @@ resource "aws_elasticache_replication_group" "redis" {
   snapshot_window               = var.redis_snapshot_window
   snapshot_retention_limit      = var.redis_snapshot_retention_limit
   tags                          = merge(tomap({ "Name" = format("tf-elasticache-%s-%s", var.name, var.vpc_id) }), var.tags)
-
-  dynamic "cluster_mode" {
-    for_each = var.redis_cluster_enable ? [1] : [0]
-    content {
-      num_node_groups         = var.redis_cluster_num_node_groups
-      replicas_per_node_group = var.redis_cluster_replicas_per_node_group
-    }
-  }
+  num_node_groups               = var.redis_cluster_enable ? var.redis_cluster_num_node_groups : null
+  replicas_per_node_group       = var.redis_cluster_enable ? var.redis_cluster_replicas_per_node_group : null
 }
 
 resource "aws_elasticache_parameter_group" "redis_parameter_group" {


### PR DESCRIPTION
Just a deprecated attribute fix to move from `aws_subnet_ids` to `aws_subnets`.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.
