### PR TITLE
Allow Redis subnet group to be managed outside of the module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_elasticache_replication_group" "redis" {
   engine_version             = var.redis_version
   port                       = var.redis_port
   parameter_group_name       = aws_elasticache_parameter_group.redis_parameter_group.id
-  subnet_group_name          = aws_elasticache_subnet_group.redis_subnet_group.id
+  subnet_group_name          = try(aws_elasticache_subnet_group.redis_subnet_group[0].id, var.redis_subnet_group_id)
   security_group_names       = var.security_group_names
   security_group_ids         = [aws_security_group.redis_security_group.id]
   snapshot_arns              = var.snapshot_arns
@@ -59,6 +59,7 @@ resource "aws_elasticache_parameter_group" "redis_parameter_group" {
 }
 
 resource "aws_elasticache_subnet_group" "redis_subnet_group" {
+  count      = var.create_redis_subnet_group ? 1 : 0
   name       = replace(format("%.255s", lower(replace("tf-redis-${var.name}-${var.env}-${var.vpc_id}", "_", "-"))), "/\\s/", "-")
   subnet_ids = data.aws_subnets.selected.ids
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,7 +7,7 @@ output "parameter_group" {
 }
 
 output "redis_subnet_group_name" {
-  value = aws_elasticache_subnet_group.redis_subnet_group.name
+  value = var.create_redis_subnet_group == true ? aws_elasticache_subnet_group.redis_subnet_group[0].name : ""
 }
 
 output "id" {

--- a/variables.tf
+++ b/variables.tf
@@ -219,3 +219,13 @@ variable "user_group_ids" {
   type        = set(string)
   default     = null
 }
+
+variable "create_redis_subnet_group" {
+  description = "Create a Subnet group?"
+  default     = true
+}
+
+variable "redis_subnet_group_id" {
+  description = "Redis subnet group id"
+  type        = string  
+}

--- a/variables.tf
+++ b/variables.tf
@@ -227,5 +227,5 @@ variable "create_redis_subnet_group" {
 
 variable "redis_subnet_group_id" {
   description = "Redis subnet group id"
-  type        = string  
+  type        = string
 }


### PR DESCRIPTION
In a shared VPC model, the Redis Subnet group should not be created from the module. Instead, it should be managed outside and referenced using a variable `redis_subnet_group_id`.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the CONTRIBUTING.md doc.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...